### PR TITLE
added launch detect to change states from idle to ascent

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,14 @@
+/*!
+ *  @file main.cpp
+ *
+ *  This file contains the main logic for the LIGMA flight computer.
+ *
+ *  Uses a state machine for data acquisition and dual-parachute deployment.
+ * 
+ *  By: Jonic Mecija
+ *  Date: 8/28/22
+ */
+
 #include <Wire.h>
 #include <SPI.h>
 #include <Adafruit_BMP280.h>
@@ -9,17 +20,21 @@
 #define BMP_MOSI (11)
 #define BMP_CS   (10)
 
+enum Rocket_States
+{
+  IDLE_STATE,
+  ASCENT_STATE,
+  DESCENT_STATE,
+  RECOVERY_STATE
+};
+
 // Initial state set to IDLE_STATE
 Rocket_States curr_state = IDLE_STATE;
 Adafruit_BMP280 bmp(BMP_CS); // hardware SPI
 
-enum Rocket_States
-{
-    IDLE_STATE,
-    ASCENT_STATE,
-    DESCENT_STATE,
-    RECOVERY_STATE
-};
+// set global variable to keep track of altitude
+float curr_altitude = 0;
+float initial_altitude = 0;
 
 void setup() {
   Serial.begin(9600);
@@ -39,28 +54,48 @@ void setup() {
                   Adafruit_BMP280::SAMPLING_X16,    /* Pressure oversampling */
                   Adafruit_BMP280::FILTER_X16,      /* Filtering. */
                   Adafruit_BMP280::STANDBY_MS_500); /* Standby time. */
+  
+  initial_altitude = bmp.readAltitude(1013.25);
+  curr_altitude = initial_altitude;
 }
 
 void loop() {
   switch(curr_state){
     case Rocket_States::IDLE_STATE:
       Serial.println("idle state");
-      curr_state = Rocket_States::ASCENT_STATE;
+      
+      Serial.print("Current Altitude: ");
+      Serial.print(curr_altitude);
+      Serial.println(" m");
+
+      Serial.print("Initial Altitude: ");
+      Serial.print(initial_altitude);
+      Serial.println(" m");
+      Serial.println(" ");
+
+      // if change in z axis altimeter has changed dramatically, change state
+      if (curr_altitude - initial_altitude > 0.3){
+        Serial.println("Launch detected. Changing state.");
+        curr_state = Rocket_States::ASCENT_STATE;
+      }
       break;
+
     case Rocket_States::ASCENT_STATE:
       Serial.println("ascent state");
+      // if rocket is descending, change state
       curr_state = Rocket_States::DESCENT_STATE;
       break;
+      
     case Rocket_States::DESCENT_STATE:
       Serial.println("descent state");
-      curr_state = Rocket_States::RECOVERY_STATE;
+      // when rocket hits certain altitude, fire main parachute
+      // curr_state = Rocket_States::RECOVERY_STATE;
       break;
     case Rocket_States::RECOVERY_STATE:
       Serial.println("recovery state");
-      curr_state = Rocket_States::IDLE_STATE;
+      // curr_state = Rocket_States::IDLE_STATE;
       break;
   }
-  //test
   /* BMP280 Sensor Readings */
   // Serial.print(F("Temperature = "));
   // Serial.print(bmp.readTemperature());
@@ -70,8 +105,9 @@ void loop() {
   // Serial.println(" Pa");
   // Serial.print(F("Approx altitude = "));
   // Serial.print(bmp.readAltitude(1013.25)); /* Adjusted to local forecast! */
+  curr_altitude = bmp.readAltitude(1013.25);
   // Serial.println(" m");
   // Serial.println();
 
-  delay(2000);
+  delay(500);
 }


### PR DESCRIPTION
State machine keeps track of global altitude variable. Right now, the variable detects if there's a 0.30m change between initial altitude at start and current sampled altitude. This value should be changed to detect a 5-10m diffence instead. 0.3m was chosen because that was as far as my arm would extend from sitting at my desk in the z axis. Once the change is detected, the state changes, and is verified in the terminal prompting "Launch detected. Changing state."